### PR TITLE
Adding votes controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,3 +49,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'devise'
 gem 'rack-cors', require: 'rack/cors'
+gem 'mocha'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,12 +67,15 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
+    mocha (1.2.1)
+      metaclass (~> 0.0.1)
     multi_json (1.12.1)
     nio4r (1.2.1)
     nokogiri (1.6.8.1)
@@ -168,6 +171,7 @@ DEPENDENCIES
   devise
   jbuilder (~> 2.5)
   listen (~> 3.0.5)
+  mocha
   pg
   pry-byebug
   puma (~> 3.0)

--- a/app/controllers/api/votes_controller.rb
+++ b/app/controllers/api/votes_controller.rb
@@ -1,0 +1,21 @@
+class Api::VotesController < ApplicationController
+  def create
+    vote = Articles::Rate.new(current_user, vote_params).call
+    if vote.persisted?
+      head :created
+    else
+      render json: { errors: vote.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  # TODO
+  def current_user
+    User.first
+  end
+
+  def vote_params
+    params.require(:vote).permit(:article_url, :rating)
+  end
+end

--- a/app/jobs/articles/fetch_metadata_job.rb
+++ b/app/jobs/articles/fetch_metadata_job.rb
@@ -1,0 +1,7 @@
+class Articles::FetchMetadataJob < ApplicationJob
+  queue_as :default
+
+  def perform(article_id)
+    Articles::FetchMetadata.new(article_id).call
+  end
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -3,6 +3,7 @@ class Article < ApplicationRecord
   has_many :authors,         through: :article_authors
   has_many :article_tags,    dependent: :delete_all
   has_many :tags,            through: :article_tags
+  has_many :votes,           dependent: :delete_all
 
   validates :bs_index, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 1 }
   validates :url,      presence: true, uniqueness: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :votes, dependent: :delete_all
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -2,11 +2,7 @@ class Vote < ApplicationRecord
   belongs_to :article
   belongs_to :user
 
-  RATING_TYPES = %w(negative neutral positive).freeze
-
-  enum rating: RATING_TYPES.each_with_object({}) { |v, h| h[v] = v }
-
   validates :article, presence: true, uniqueness: { scope: :user }
   validates :user,    presence: true
-  validates :rating,  presence: true
+  validates :rating,  presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 1 }
 end

--- a/app/services/articles/fetch_metadata.rb
+++ b/app/services/articles/fetch_metadata.rb
@@ -1,0 +1,15 @@
+class Articles::FetchMetadata
+  def initialize(article_id)
+    @article_id = article_id
+  end
+
+  def call
+    # Parse HTML and create tags
+  end
+
+  private
+
+  def article
+    @article ||= Article.find(article_id)
+  end
+end

--- a/app/services/articles/find_or_create.rb
+++ b/app/services/articles/find_or_create.rb
@@ -1,0 +1,20 @@
+class Articles::FindOrCreate
+  def initialize(url)
+    @url = url
+  end
+
+  def call
+    article = Article.find_by(url: url)
+    unless article
+      article = Article.find_or_create_by(url: url)
+      Articles::FetchMetadataJob.perform_later(article.id) if article.persisted?
+    end
+    article
+  end
+
+  private
+
+  def url
+    @url
+  end
+end

--- a/app/services/articles/rate.rb
+++ b/app/services/articles/rate.rb
@@ -6,11 +6,22 @@ class Articles::Rate
   end
 
   def call
-    article = Articles::FindOrCreate.new(url).call
-    Vote.create(user: user, article: article, rating: rating)
+    vote = Vote.create(user: user, article: article, rating: rating)
+    calculate_bs_index if vote.persisted?
+
+    vote
   end
 
   private
+
+  def article
+    @article ||= Articles::FindOrCreate.new(url).call
+  end
+
+  def calculate_bs_index
+    bs_index = article.votes.sum(:rating).to_f / article.votes.count
+    @article.update!(bs_index: bs_index)
+  end
 
   def user
     @user

--- a/app/services/articles/rate.rb
+++ b/app/services/articles/rate.rb
@@ -1,0 +1,26 @@
+class Articles::Rate
+  def initialize(user, params)
+    @user = user
+    @rating = params[:rating]
+    @url = params[:article_url]
+  end
+
+  def call
+    article = Articles::FindOrCreate.new(url).call
+    Vote.create(user: user, article: article, rating: rating)
+  end
+
+  private
+
+  def user
+    @user
+  end
+
+  def url
+    @url
+  end
+
+  def rating
+    @rating
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  namespace :api do
+    resources :votes, only: [:create]
+  end
+
   devise_for :users
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20161210180133_create_rating_enum.rb
+++ b/db/migrate/20161210180133_create_rating_enum.rb
@@ -1,6 +1,8 @@
 class CreateRatingEnum < ActiveRecord::Migration[5.0]
+  RATING_TYPES = %w(negative neutral positive).freeze
+
   def up
-    values = Vote::RATING_TYPES.map { |v| "'#{v}'" }.join(',')
+    values = RATING_TYPES.map { |v| "'#{v}'" }.join(',')
     execute "CREATE TYPE rating_enum AS ENUM (#{values})"
   end
 

--- a/db/migrate/20161210235250_change_rating_to_float.rb
+++ b/db/migrate/20161210235250_change_rating_to_float.rb
@@ -1,0 +1,17 @@
+class ChangeRatingToFloat < ActiveRecord::Migration[5.0]
+  RATING_TYPES = %w(negative neutral positive).freeze
+
+  def up
+    remove_column :votes, :rating
+    execute "DROP TYPE rating_enum"
+    add_column :votes, :rating, :float, null: false
+  end
+
+  def down
+    values = RATING_TYPES.map { |v| "'#{v}'" }.join(',')
+
+    remove_column :votes, :rating
+    execute "CREATE TYPE rating_enum AS ENUM (#{values})"
+    add_column :votes, :rating, :rating_enum, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -39,17 +39,6 @@ COMMENT ON EXTENSION citext IS 'data type for case-insensitive character strings
 
 SET search_path = public, pg_catalog;
 
---
--- Name: rating_enum; Type: TYPE; Schema: public; Owner: -
---
-
-CREATE TYPE rating_enum AS ENUM (
-    'negative',
-    'neutral',
-    'positive'
-);
-
-
 SET default_tablespace = '';
 
 SET default_with_oids = false;
@@ -282,9 +271,9 @@ CREATE TABLE votes (
     id integer NOT NULL,
     user_id integer NOT NULL,
     article_id integer NOT NULL,
-    rating rating_enum NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    rating double precision NOT NULL
 );
 
 
@@ -587,6 +576,6 @@ ALTER TABLE ONLY votes
 
 SET search_path TO "$user",public;
 
-INSERT INTO schema_migrations (version) VALUES ('20161210062100'), ('20161210064200'), ('20161210070349'), ('20161210072256'), ('20161210180133'), ('20161210180900'), ('20161210183056'), ('20161210185832'), ('20161210192027');
+INSERT INTO schema_migrations (version) VALUES ('20161210062100'), ('20161210064200'), ('20161210070349'), ('20161210072256'), ('20161210180133'), ('20161210180900'), ('20161210183056'), ('20161210185832'), ('20161210192027'), ('20161210235250');
 
 

--- a/test/controllers/api/votes_controller_test.rb
+++ b/test/controllers/api/votes_controller_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+require 'mocha/mini_test'
+
+class Api::VotesControllerTest < ActionDispatch::IntegrationTest
+  test "post create should be successful" do
+    Api::VotesController.stubs(:current_user).with(users(:paco))
+    service = mock('Articles::Rate service')
+    Articles::Rate.expects(:new).returns(service)
+    service.expects(:call).returns(votes(:bullshit_negative))
+
+    post "/api/votes", params: { vote: { article_url: 'https://articles.example.com/foo', rating: 'neutral' } }
+
+    assert_response :success
+  end
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,2 +1,5 @@
 paco:
   email: paco@bullshitmeter.site
+francisco:
+  email: francisco@bullshitmeter.site
+

--- a/test/fixtures/votes.yml
+++ b/test/fixtures/votes.yml
@@ -1,5 +1,5 @@
 bullshit_negative:
   article: bullshit
   user: paco
-  rating: negative
+  rating: 0
 

--- a/test/jobs/articles/fetch_metadata_job_test.rb
+++ b/test/jobs/articles/fetch_metadata_job_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+require 'mocha/mini_test'
+
+class Articles::FetchMetadataJobTest < ActiveJob::TestCase
+  test "should call service Articles::FetchMetadata" do
+    article_id = articles(:bullshit).id
+    service = mock('Articles::FetchMetadata Service')
+    Articles::FetchMetadata.expects(:new).with(article_id).returns(service)
+    service.expects(:call)
+
+    Articles::FetchMetadataJob.perform_now(article_id)
+  end
+end

--- a/test/models/vote_test.rb
+++ b/test/models/vote_test.rb
@@ -18,8 +18,16 @@ class VoteTest < ActiveSupport::TestCase
     assert_invalid? votes(:bullshit_negative).dup, article: "has already been taken"
   end
 
+  test 'rating should be greater than or equal to 0' do
+    assert_invalid? Vote.new(rating: -0.1), rating: 'must be greater than or equal to 0'
+  end
+
+  test 'rating should be less than or equal to 1' do
+    assert_invalid? Vote.new(rating: 1.1), rating: 'must be less than or equal to 1'
+  end
+
   test "should be valid if all requirements are met" do
-    assert_valid? Vote.new(article: articles(:legit), user: users(:paco), rating: "positive")
+    assert_valid? Vote.new(article: articles(:legit), user: users(:paco), rating: 1)
   end
 
   test "fixtures should be valid" do

--- a/test/services/articles/find_or_create_test.rb
+++ b/test/services/articles/find_or_create_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+require "mocha/test_unit"
+
+class FindOrCreateArticleTest < ActiveSupport::TestCase
+  test "should return existing article if url already exists" do
+    assert_equal articles(:bullshit), Articles::FindOrCreate.new(articles(:bullshit).url).call
+  end
+
+  test "should create a new article if url doesn't exist" do
+    assert_difference "Article.count" do
+      Articles::FetchMetadataJob.expects(:perform_now)
+      Articles::FindOrCreate.new('https://awesome.article.com/article').call
+    end
+  end
+end

--- a/test/services/articles/find_or_create_test.rb
+++ b/test/services/articles/find_or_create_test.rb
@@ -3,12 +3,13 @@ require "mocha/test_unit"
 
 class FindOrCreateArticleTest < ActiveSupport::TestCase
   test "should return existing article if url already exists" do
+    Articles::FetchMetadataJob.expects(:perform_later).times(0)
     assert_equal articles(:bullshit), Articles::FindOrCreate.new(articles(:bullshit).url).call
   end
 
-  test "should create a new article if url doesn't exist" do
+  test "should create a new article and fetch metadata if url doesn't exist" do
     assert_difference "Article.count" do
-      Articles::FetchMetadataJob.expects(:perform_now)
+      Articles::FetchMetadataJob.expects(:perform_later)
       Articles::FindOrCreate.new('https://awesome.article.com/article').call
     end
   end

--- a/test/services/articles/rate_test.rb
+++ b/test/services/articles/rate_test.rb
@@ -3,16 +3,21 @@ require "mocha/test_unit"
 
 class RateArticleTest < ActiveSupport::TestCase
   setup do
-    @user = users(:paco)
+    @user = users(:francisco)
+    @article = articles(:bullshit)
   end
 
   test "should create a new vote for an article" do
     service = mock('Articles::FindOrCreate service')
     Articles::FindOrCreate.expects(:new).with('https://url').returns(service)
-    service.expects(:call).returns(articles(:legit))
+    service.expects(:call).returns(@article)
 
     assert_difference '@user.votes.count' do
-      Articles::Rate.new(@user, { rating: 'neutral', article_url: 'https://url' }).call
+      assert_equal 0, @article.bs_index
+
+      Articles::Rate.new(@user, { rating: 0.5, article_url: 'https://url' }).call
+
+      assert_equal 0.25, @article.bs_index
     end
   end
 end

--- a/test/services/articles/rate_test.rb
+++ b/test/services/articles/rate_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+require "mocha/test_unit"
+
+class RateArticleTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:paco)
+  end
+
+  test "should create a new vote for an article" do
+    service = mock('Articles::FindOrCreate service')
+    Articles::FindOrCreate.expects(:new).with('https://url').returns(service)
+    service.expects(:call).returns(articles(:legit))
+
+    assert_difference '@user.votes.count' do
+      Articles::Rate.new(@user, { rating: 'neutral', article_url: 'https://url' }).call
+    end
+  end
+end


### PR DESCRIPTION
Create several services objects:
- `Articles::FindOrCreate`
- `Articles::Rate`
- `Articles::FetchMetadata`(placeholder only)

Create bg job `Articles::FetchMetadataJob` that calls the homonym  service.

Create endpoint for creating votes. This will create an article by its url if it doesn't exist already, and rate it.

Change `rating` column in the `Vote` model to be a float, to make it easier to calculate the `bs_index`. 

TODOs:
- [ ] Extract the calculation of the `bs_index` to a service, it might be interesting to execute it async